### PR TITLE
Add version button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Alpine.js
 
+![npm version](https://img.shields.io/npm/v/alpinejs)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/alpinejs)
 
 Alpine.js offers you the reactive and declarative nature of big frameworks like Vue or React at a much lower cost.


### PR DESCRIPTION
Personally, I find it useful to be able to go to a package's repo and immediately see what the latest version is. This PR adds an npm version button to the top of the README.